### PR TITLE
Add list and remove members

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -253,6 +253,20 @@ async def stockfish(ctx):
 
 @bot.tree.command(name="list_members", description="List members based on role conditions with confirmation.")
 async def list_members(interaction: discord.Interaction, role_condition: str = "@everyone"):
+    """
+    Lists members based on role conditions with confirmation.
+    Args:
+        interaction (discord.Interaction): The interaction object representing the command invocation.
+        role_condition (str, optional): The role condition to filter members by. Defaults to "@everyone".
+    Returns:
+        None: This function sends messages to the interaction response and does not return any value.
+    Raises:
+        None: This function does not raise any exceptions.
+    Notes:
+        - Only members with the "HKN Exec Comm" role are allowed to use this command.
+        - If no members match the role condition, a message is sent indicating no members were found.
+        - A confirmation message is sent before listing the members, with a view containing Yes/No buttons for confirmation.
+    """
     """Lists members based on role conditions with confirmation."""
     AllowedRoles = ["HKN Exec Comm"]
     if not any(role.name in AllowedRoles for role in interaction.user.roles):
@@ -288,6 +302,19 @@ async def list_members(interaction: discord.Interaction, role_condition: str = "
 
 @bot.tree.command(name="remove_members", description="Remove members based on role conditions with confirmation.")
 async def remove_members(interaction: discord.Interaction, role_condition: str):
+    """
+    Remove members (kick) based on role conditions, with confirmation.
+    Args:
+        interaction (discord.Interaction): The interaction object representing the command invocation.
+        role_condition (str): The condition to check against members' roles.
+    Returns:
+        None
+    Behavior:
+        - Checks if the user invoking the command has the required role.
+        - Parses the role condition and identifies members matching the condition.
+        - If no members match the condition, sends a message indicating so.
+        - Lists members matching the condition and asks for confirmation before removal.
+    """
     """Remove members (kick) based on role conditions, with confirmation."""
     AllowedRoles = ["HKN Exec Comm"]
     if not any(role.name in AllowedRoles for role in interaction.user.roles):
@@ -321,6 +348,17 @@ async def remove_members(interaction: discord.Interaction, role_condition: str):
 
 # Helper Stuff
 def process_roles_condition(roles_string, member_roles):
+    """
+    Process the role condition string and check if the member's roles match.
+    The roles_string can contain roles separated by OR (|) and AND (&) operators.
+    Parentheses can be used to group conditions. The NOT operator (!) can be used
+    to negate a role condition.
+    Args:
+        roles_string (str): The string representing the role conditions.
+        member_roles (list): The list of roles that the member has.
+    Returns:
+        bool: True if the member's roles match the conditions, False otherwise.
+    """
     """Process the role condition string and check if the member's roles match."""
     def evaluate_condition(condition, member_roles):
         """Evaluate a single condition or a parenthesized group."""

--- a/bot.py
+++ b/bot.py
@@ -16,6 +16,7 @@ with open ("secrets.env", "r") as file:
 
 intents = discord.Intents.default()
 intents.message_content = True
+intents.members = True
 bot = commands.Bot(command_prefix='-', intents=intents)
 board = chess.Board()
 
@@ -277,23 +278,23 @@ async def list_members(interaction: discord.Interaction, role_condition: str = "
     # List members and ask for confirmation
     member_names = [f"{member.name}\t Roles: {', '.join([role.name for role in member.roles if role.name != '@everyone'])}" for member in members_to_list]
     if role_condition == "@everyone":
-        confirmation_msg = "All members:\n"
+        confirmation_msg = "List all members in the server?"
     else:
-        confirmation_msg = f"The following members match the role condition '{role_condition}':\n"
-    confirmation_msg += "\n".join(member_names)
+        confirmation_msg = f"list {len(members_to_list)} members based on the role condition '{role_condition}'?"
 
     # Create a confirmation view (with buttons for Yes/No)
-    await interaction.response.send_message(confirmation_msg)
+    view = ConfirmationView(interaction, members_to_list, role_condition, action='list')
+    await interaction.response.send_message(confirmation_msg, view=view)
 
 @bot.tree.command(name="remove_members", description="Remove members based on role conditions with confirmation.")
-async def remove_members(ctx, role_condition: str):
+async def remove_members(interaction: discord.Interaction, role_condition: str):
     """Remove members (kick) based on role conditions, with confirmation."""
     AllowedRoles = ["HKN Exec Comm"]
-    if not any(role.name in AllowedRoles for role in ctx.author.roles):
-        await ctx.send(f"You do not have permission to use this command. Only members with the {AllowedRoles} role can use it.")
+    if not any(role.name in AllowedRoles for role in interaction.user.roles):
+        await interaction.response.send_message(f"You do not have permission to use this command. Only members with the {AllowedRoles} role can use it.")
         return
     
-    guild = ctx.guild
+    guild = interaction.guild
     members_to_remove = []
 
     # Parse the condition and loop through all members
@@ -306,17 +307,17 @@ async def remove_members(ctx, role_condition: str):
 
     # If no members match the condition
     if not members_to_remove:
-        await ctx.send(f"No members found matching '{role_condition}'.")
+        await interaction.response.send_message(f"No members found matching '{role_condition}'.")
         return
 
     # List members and ask for confirmation
-    member_names = [f"{member.name}\t Roles: {', '.join([role.name for role in member.roles if role.name != '@everyone'])}" for member in members_to_remove]
+    member_names = [f"{member.mention} ({member.name})\t Roles: {', '.join([role.name for role in member.roles if role.name != '@everyone'])}" for member in members_to_remove]
     confirmation_msg = f"The following members will be removed based on the role condition '{role_condition}':\n"
     confirmation_msg += "\n".join(member_names)
 
     # Create a confirmation view (with buttons for Yes/No)
-    view = ConfirmationView(ctx, members_to_remove, role_condition, action='remove')
-    await ctx.send(confirmation_msg, view=view)
+    view = ConfirmationView(interaction, members_to_remove, role_condition, action='remove')
+    await interaction.response.send_message(confirmation_msg, view=view)
 
 # Helper Stuff
 def process_roles_condition(roles_string, member_roles):
@@ -348,9 +349,9 @@ def process_roles_condition(roles_string, member_roles):
     return False
 
 class ConfirmationView(View):
-    def __init__(self, ctx, members_to_remove, role_condition, action):
+    def __init__(self, interaction, members_to_remove, role_condition, action):
         super().__init__(timeout=30)  # Set timeout for response (30 seconds)
-        self.ctx = ctx
+        self.interaction = interaction
         self.members_to_remove = members_to_remove
         self.role_condition = role_condition
         self.action = action  # Action to perform (either 'remove' or 'list')
@@ -358,16 +359,21 @@ class ConfirmationView(View):
     
     async def on_timeout(self):
         """Handle timeout if the user doesn't respond in time."""
-        await self.ctx.send("Confirmation timeout. No action was taken.")
+        await self.interaction.followup.send("Confirmation timeout. No action was taken.")
 
     @discord.ui.button(label="Yes", style=discord.ButtonStyle.green)
     async def confirm(self, interaction: discord.Interaction, button: Button):
         """Handles the confirmation response."""
         self.confirmed = True
-        await interaction.response.send_message(f"Proceeding with the action: {self.action} for {len(self.members_to_remove)} member(s).")
+        await interaction.response.edit_message(content=interaction.message.content + f"\nProceeding with the action: {self.action} for {len(self.members_to_remove)} member(s).")
 
         # Perform the action (remove members or list them)
         if self.action == 'remove':
+            # Check if the bot has the permissions and role hierarchy is correct
+            if not interaction.guild.me.guild_permissions.kick_members:
+                await interaction.followup.send("I do not have the 'Kick Members' permission.")
+                return
+            
             members_removed = []
             for member in self.members_to_remove:
                 try:
@@ -379,22 +385,28 @@ class ConfirmationView(View):
                     print(f"Failed to remove {member.name}: {e}")
 
             if members_removed:
-                await self.ctx.send(f"Members removed: {', '.join(members_removed)}")
+                await self.interaction.followup.send(f"Members removed: {', '.join(members_removed)}")
             else:
-                await self.ctx.send(f"No members could be removed.")
+                await self.interaction.followup.send(f"No members could be removed.")
         elif self.action == 'list':
-            member_names = [member.name for member in self.members_to_remove]
-            await self.ctx.send(f"Members matching '{self.role_condition}':\n" + "\n".join(member_names))
+            member_names = [f"{member.display_name}\t\t ({member.name})\t Roles:  {', '.join([role.name for role in member.roles if role.name != '@everyone'])}" for member in self.members_to_remove]
+            await self.interaction.followup.send(f"Members matching '{self.role_condition}':\n" + "\n".join(member_names))
 
         # Stop the view from accepting further responses
         self.stop()
+        # Remove the button after the action is completed
+        for child in self.children:
+            child.disabled = True
+        await interaction.message.edit(view=self)
 
     @discord.ui.button(label="No", style=discord.ButtonStyle.red)
     async def cancel(self, interaction: discord.Interaction, button: Button):
         """Handles the cancellation response."""
         self.confirmed = False
-        await interaction.response.send_message(f"Action canceled. No members were {self.action}ed.")
+        # await interaction.response.send_message(f"Action canceled. No members were {self.action}ed.", ephemeral=True)
         self.stop()
+        # Remove the original message
+        await interaction.message.delete()
 
 
 bot.run(token)


### PR DESCRIPTION
Added `/list_members` and `/remove_members` command. Both take a ``role_condition`` which is a string of roles and logical operators. Currently supports & (AND), | (OR), ! (NOT), and parentheses for grouping. The use of these commands is gated behind the "HKN Exec Comm" Role.

EX:
```
/list_members "candidate & !member"
```